### PR TITLE
fix : revert the message signature of obj_create

### DIFF
--- a/flask_sqa_restless/resources.py
+++ b/flask_sqa_restless/resources.py
@@ -645,7 +645,7 @@ class FlaskSQAResource(FlaskResource):
         except NoResultFound:
             return self.obj_create(data)
 
-    def obj_create(self, data, commit=True, **kwargs):
+    def obj_create(self, data, commit=True):
         obj = self.load_model(data)
         self.session.add(obj)
         if commit:


### PR DESCRIPTION
**kwargs was added to obj_create in the last revision. This
functionality is not of immediate use, and might break dependent
 modules. Reverting it till dependent modules are ready to be modified.